### PR TITLE
Add github private commit data

### DIFF
--- a/pages/api/get-github-commits.ts
+++ b/pages/api/get-github-commits.ts
@@ -1,6 +1,23 @@
 import { Octokit } from 'octokit';
 import type { NextApiRequest, NextApiResponse } from "next";
 
+// supplementalCommits represents commits not available via the GitHub API due to repo restrictions
+// validity can be determined by visiting http://github.com/patrick-rush
+const supplementalCommits = [
+  {
+    date: "2023-02-14T12:00:00Z",
+    source: "GitHub"
+  },
+  {
+    date: "2023-10-27T12:00:00Z",
+    source: "GitHub"
+  },
+  {
+    date: "2023-11-03T12:00:00Z",
+    source: "GitHub"
+  },
+]
+
 export default async function handler(
     req: NextApiRequest,
     res: NextApiResponse
@@ -57,6 +74,8 @@ export default async function handler(
         }
 
         const commits = await fetchAllCommits()
+
+        if (supplementalCommits) commits.push(...supplementalCommits)
     
         return res.status(200).json({
             message: "Success",

--- a/src/components/CommitGrid.tsx
+++ b/src/components/CommitGrid.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState, useEffect, useMemo, useCallback, Suspense } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import type { Dispatch, SetStateAction} from 'react'
 
 interface Month {
@@ -142,6 +142,22 @@ export const CommitGrid = () => {
         return contributions;
     }, [gitHubData, gitLabData, daysIntoYear]);
 
+    let activeContributions: {
+        [key: number]: Contribution[] | undefined;
+    }
+    
+    switch (active) {
+        case 'github':
+            activeContributions = gitHubContributions
+            break
+        case 'gitlab':
+            activeContributions = gitLabContributions
+            break
+        default:
+            activeContributions = allContributions
+            break
+    }
+
     return (
         <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
             <h2 className="flex justify-between text-sm font-semibold text-zinc-900 dark:text-zinc-100">
@@ -150,8 +166,7 @@ export const CommitGrid = () => {
                     <span className="ml-3">Commits</span>
                 </div>
                 <div className="flex justify-between space-x-3">
-                    <span onClick={() => setActive('all')}
-                    className={`cursor-pointer ${active === 'all' ? "text-teal-500 dark:text-teal-400" : "text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"}`}>All</span>
+                    <span onClick={() => setActive('all')} className={`cursor-pointer ${active === 'all' ? "text-teal-500 dark:text-teal-400" : "text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"}`}>All</span>
                     <span onClick={() => setActive('github')} className={`cursor-pointer ${active === 'github' ? "text-teal-500 dark:text-teal-400" : "text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"}`}>GitHub</span>
                     <span onClick={() => setActive('gitlab')} className={`cursor-pointer ${active === 'gitlab' ? "text-teal-500 dark:text-teal-400" : "text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"}`}>GitLab</span>
                 </div>
@@ -173,19 +188,6 @@ export const CommitGrid = () => {
                             {Array.from({ length: 52 }).map((_, colIndex) => {
 
                                 const location = ((colIndex * 7) + (rowIndex + 1)) - months[0].firstDay
-                                
-                                let activeContributions
-                                switch (active) {
-                                    case 'github':
-                                        activeContributions = gitHubContributions
-                                        break
-                                    case 'gitlab':
-                                        activeContributions = gitLabContributions
-                                        break
-                                    default:
-                                        activeContributions = allContributions
-                                        break
-                                }
 
                                 const contributionsPerLocation = activeContributions[location]
                                 const numberOfCommits = contributionsPerLocation?.length || 0


### PR DESCRIPTION
The GitHub REST API currently does not support retrieving commit data for private repositories for individual users. A small amount of supplemental data has been added to reflect the private commits that are not able to be shown via the GitHub REST API.